### PR TITLE
Add option to keep scrolling when outside container

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ var scroll = autoScroll([
     ],{
     margin: 20,
     pixels: 5,
+    scrollWhenOutside: true,
     autoScroll: function(){
         //Only scroll when the pointer is down, and there is a child being dragged.
         return this.down && drake.dragging;
@@ -107,6 +108,7 @@ For clarity here is a more complete example:
         ],{
         margin: 20,
         pixels: 5,
+        scrollWhenOutside: false,
         autoScroll: function(){
             return this.down && drake.dragging;
         }
@@ -140,6 +142,10 @@ Return a boolean value from this function to allow scrolling.
 #### options.pixels = Integer
 
 Set how many pixels per second you want to scroll during the auto scrolling action. More is smoother.
+
+#### options.scrollWhenOutside = Boolean
+
+Whther or not it should continue to scroll when the pointer is outside the container. Defaults to **false**.
 
 Auto Scroller Properties
 ------------------------

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function AutoScroller(elements, options){
 
     this.margin = options.margin || -1;
     this.scrolling = false;
+    this.scrollWhenOutside = options.scrollWhenOutside || false;
 
     this.point = pointer(elements);
 
@@ -47,7 +48,7 @@ function AutoScroller(elements, options){
 
         if(!el) return;
         if(!self.autoScroll()) return;
-        if(!this.inside(el)) return;
+        if(!self.scrollWhenOutside && this.outside(el)) return;
 
         if(self.point.y < rect.top + self.margin){
             autoScrollV(el, -1, rect);
@@ -65,7 +66,7 @@ function AutoScroller(elements, options){
     function autoScrollV(el, amount, rect){
         //if(!self.down) return;
         if(!self.autoScroll()) return;
-        if(!self.point.inside(el)) return;
+        if(!self.scrollWhenOutside && self.point.outside(el)) return;
         if(el === window){
             window.scrollTo(el.pageXOffset, el.pageYOffset + amount);
         }else{
@@ -84,7 +85,7 @@ function AutoScroller(elements, options){
     function autoScrollH(el, amount, rect){
         //if(!self.down) return;
         if(!self.autoScroll()) return;
-        if(!self.point.inside(el)) return;
+        if(!self.scrollWhenOutside && self.point.outside(el)) return;
         if(el === window){
             window.scrollTo(el.pageXOffset + amount, el.pageYOffset);
         }else{


### PR DESCRIPTION
This PR adds an option to allow the container to be scrolled even when the cursor (pointer) is outside its boundaries.

I opted to have it default to `false`. However, I can definitely change it if you think it would make sense.
