### PR TITLE
Add ability to destroy autoscroller

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ Auto Scroller Methods
 
 The function you set in the constructor options for `options.autoScroll`.
 
+### destroy
+
+Remove all event listeners needed to be able track the pointer.
+
 About
 -----
 

--- a/index.js
+++ b/index.js
@@ -30,6 +30,10 @@ function AutoScroller(elements, options){
         this.autoScroll = options.autoScroll;
     }
 
+    this.destroy = function() {
+        this.point.destroy();
+    };
+
     Object.defineProperties(this, {
         down: {
             get: function(){ return self.point.down; }


### PR DESCRIPTION
Useful when building complex applications where events need to be cleaned up before leaving a page and rendering a different one.
