### PR TITLE
Added options to limit outer scroll space

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,10 @@ function AutoScroller(elements, options = {}){
     this.margin = options.margin || -1;
     //this.scrolling = false;
     this.scrollWhenOutside = options.scrollWhenOutside || false;
+    // those two X and Y options might be merged together, even with the original scrollWhenOutside
+    // for now, all are kept for compatibility reasons
+    this.scrollWhenOutsideX = options.scrollWhenOutsideX == undefined ? this.scrollWhenOutside : options.scrollWhenOutsideX;
+    this.scrollWhenOutsideY = options.scrollWhenOutsideY == undefined ? this.scrollWhenOutside : options.scrollWhenOutsideY;
 
     let point = {},
         pointCB = createPointCB(point),
@@ -197,7 +201,7 @@ function AutoScroller(elements, options = {}){
         let target = event.target, body = document.body;
 
         if(current && !inside(point, current)){
-            if(!self.scrollWhenOutside){
+            if(!self.scrollWhenOutside && !self.scrollWhenOutsideX && !self.scrollWhenOutsideY){
                 current = null;
             }
         }
@@ -256,27 +260,14 @@ function AutoScroller(elements, options = {}){
     function autoScroll(el){
         let rect = getRect(el), scrollx, scrolly;
 
-        if(point.x < rect.left + self.margin){
-            scrollx = Math.floor(
-                Math.max(-1, (point.x - rect.left) / self.margin - 1) * self.maxSpeed
-            );
-        }else if(point.x > rect.right - self.margin){
-            scrollx = Math.ceil(
-                Math.min(1, (point.x - rect.right) / self.margin + 1) * self.maxSpeed
-            );
-        }else{
-            scrollx = 0;
-        }
+        scrollx = deltaX(point, rect, self);
+        scrolly = deltaY(point, rect, self);
 
-        if(point.y < rect.top + self.margin){
-            scrolly = Math.floor(
-                Math.max(-1, (point.y - rect.top) / self.margin - 1) * self.maxSpeed
-            );
-        }else if(point.y > rect.bottom - self.margin){
-            scrolly = Math.ceil(
-                Math.min(1, (point.y - rect.bottom) / self.margin + 1) * self.maxSpeed
-            );
-        }else{
+        const horizontallyInside = point.x >= rect.left && point.x <= rect.right;
+        const verticallyInside = point.y >= rect.top && point.y <= rect.bottom;
+        
+        if (!self.scrollWhenOutsideX && !horizontallyInside || !self.scrollWhenOutsideY && !verticallyInside) {
+            scrollx = 0;
             scrolly = 0;
         }
 
@@ -306,6 +297,32 @@ function AutoScroller(elements, options = {}){
             }
 
         });
+    }
+
+    function deltaX(point, rect, autoscroller) {
+        if(point.x < rect.left + autoscroller.margin){
+            return Math.floor(
+                Math.max(-1, (point.x - rect.left) / autoscroller.margin - 1) * autoscroller.maxSpeed
+            );
+        }else if(point.x > rect.right - autoscroller.margin){
+            return Math.ceil(
+                Math.min(1, (point.x - rect.right) / autoscroller.margin + 1) * autoscroller.maxSpeed
+            );
+        }
+        return 0;
+    }
+
+    function deltaY(point, rect, autoscroller) {
+        if(point.y < rect.top + autoscroller.margin){
+            return Math.floor(
+                Math.max(-1, (point.y - rect.top) / autoscroller.margin - 1) * autoscroller.maxSpeed
+            );
+        }else if(point.y > rect.bottom - autoscroller.margin){
+            return Math.ceil(
+                Math.min(1, (point.y - rect.bottom) / autoscroller.margin + 1) * autoscroller.maxSpeed
+            );
+        }
+        return 0;
     }
 
     function scrollY(el, amount){


### PR DESCRIPTION
This PR fixes https://github.com/hollowdoor/dom_autoscroller/issues/33

Basically it allows the user to configure two additional boolean options **scrollWhenOutsideX** and **scrollWhenOutsideY** to limit which pointer position outside of the scrollable element is permitted to scroll it.

By setting first scrollWhenOutsideX and secondly scrollWhenOutsideY to false, the limitations then look like this 
![outside_zones](https://user-images.githubusercontent.com/34311965/41403226-b4ee7aaa-6fc4-11e8-8b02-69f9151da22b.png)
where only dragging in the green zones is able to scroll in the _div_. This stays in opposition to configuring setting just **scrollWhenOutside**, where the complete rectangle around the _div_ is permitted to scroll in that _div_.

This solves the problem of two scrollable divs next to each other while dragging and drag-scrolling between them.
![2_scroll_containers](https://user-images.githubusercontent.com/34311965/41403774-fea2cc04-6fc5-11e8-8666-db9ecd361365.png)
Without the fix, if one drags from 1 to the orange areas in 2, it scrolls both of them because the outside scrollable area of 1 isn't confined to its "natural" axis. With the fix, by specifying eg.
`
{
  scrollWhenOutsideX: false,
  scrollWhenOutsideY: true
}
`
the div nr. 1 can be only scrolled by dragging to one of the yellow areas.

Note, that I leave the **scrollWhenOutside** option there for compatiblity reasons and all those 3 are complementary.